### PR TITLE
Removes Fedimos from ActivityPub enabled projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ _WIP_
 * ![GitHub last commit](https://img.shields.io/github/last-commit/jaywink/socialhome.svg?style=plastic) [socialhome](https://github.com/jaywink/socialhome) - _Python_ "federated personal profile"
 * ![GitHub last commit](https://img.shields.io/github/last-commit/Scarly-Cat/lamia.svg?style=plastic) [Lamia](https://github.com/Scarly-Cat/lamia) - _Python_ "Distributed blogging, polls, and status updates powered by activitypub, python, the gay agenda, and snake women."
 * ![GitHub last commit](https://img.shields.io/github/last-commit/pubcast/pubcast.svg?style=plastic) [Pubcast](https://github.com/pubcast/pubcast) - _Go_ "experimental ActivityPub based podcasting platform"
-* ![GitHub last commit](https://img.shields.io/github/last-commit/fedimos/server.svg?style=plastic) [Fedimos](https://github.com/fedimos/server) - _NodeJS_ "End-to-End Encrypted & Decentralized Messaging Service for the Fediverse"
 * ![GitHub last commit](https://img.shields.io/github/last-commit/pterotype-project/pterotype.svg?style=plastic) [pterotype](https://github.com/pterotype-project/pterotype) - _PHP_ "WordPress plugin that expands your audience by giving your site an ActivityPub stream"
 
 


### PR DESCRIPTION
We just (officially) abandoned this project, see [here](https://github.com/fedimos/server#fedimosserver).

Sorry, and bye :wave: